### PR TITLE
Integration of GsResults into View

### DIFF
--- a/src/main/java/io/jenkins/plugins/analysis/core/model/IssuesDetail.java
+++ b/src/main/java/io/jenkins/plugins/analysis/core/model/IssuesDetail.java
@@ -244,7 +244,7 @@ public class IssuesDetail implements ModelObject {
      * @return the table model
      */
     public DetailsTableModel getScmPropertiesModel() {
-        return labelProvider.getScmPropertiesModel(owner, getUrl(), result.getBlames());
+        return labelProvider.getScmPropertiesModel(owner, getUrl(), result.getGsResults());
     }
 
     private JSONObject toJsonArray(final List<List<String>> rows) {
@@ -270,8 +270,14 @@ public class IssuesDetail implements ModelObject {
         if ("#issues".equals(id)) {
             rows = getIssuesModel().getContent(getIssues());
         }
-        else {
+        else if ("#scmBlames".equals(id)) {
             rows = getScmBlamesModel().getContent(getIssues());
+        }
+        else if ("#scmProperties".equals(id)) {
+            rows = getScmPropertiesModel().getContent(getIssues());
+        }
+        else {
+            throw new NoSuchElementException("No such table model: " + id);
         }
 
         return toJsonArray(rows);

--- a/src/main/java/io/jenkins/plugins/analysis/core/model/IssuesDetail.java
+++ b/src/main/java/io/jenkins/plugins/analysis/core/model/IssuesDetail.java
@@ -230,12 +230,21 @@ public class IssuesDetail implements ModelObject {
     }
 
     /**
+     * Returns the model for the details table that shows the SCM blames.
+     *
+     * @return the table model
+     */
+    public DetailsTableModel getScmBlamesModel() {
+        return labelProvider.getScmBlamesModel(owner, getUrl(), result.getBlames());
+    }
+
+    /**
      * Returns the model for the details table.
      *
      * @return the table model
      */
-    public DetailsTableModel getScmModel() {
-        return labelProvider.getScmModel(owner, getUrl(), result.getBlames());
+    public DetailsTableModel getScmPropertiesModel() {
+        return labelProvider.getScmPropertiesModel(owner, getUrl(), result.getBlames());
     }
 
     private JSONObject toJsonArray(final List<List<String>> rows) {
@@ -262,7 +271,7 @@ public class IssuesDetail implements ModelObject {
             rows = getIssuesModel().getContent(getIssues());
         }
         else {
-            rows = getScmModel().getContent(getIssues());
+            rows = getScmBlamesModel().getContent(getIssues());
         }
 
         return toJsonArray(rows);

--- a/src/main/java/io/jenkins/plugins/analysis/core/model/ScmPropertiesDetailsModel.java
+++ b/src/main/java/io/jenkins/plugins/analysis/core/model/ScmPropertiesDetailsModel.java
@@ -7,7 +7,8 @@ import edu.hm.hafner.analysis.Issue;
 import edu.hm.hafner.analysis.Report;
 
 import io.jenkins.plugins.analysis.core.model.StaticAnalysisLabelProvider.AgeBuilder;
-import io.jenkins.plugins.analysis.core.scm.Blames;
+import io.jenkins.plugins.analysis.core.scm.GsResult;
+import io.jenkins.plugins.analysis.core.scm.GsResults;
 
 /**
  * Provides the model for the source control details table. The model consists of the following parts:
@@ -24,14 +25,13 @@ import io.jenkins.plugins.analysis.core.scm.Blames;
 class ScmPropertiesDetailsModel extends DetailsTableModel {
     static final String UNDEFINED = "-";
 
-    // FIXME: replace with Dipp Model
-    private final Blames blames;
+    private final GsResults gsResults;
 
     ScmPropertiesDetailsModel(final AgeBuilder ageBuilder, final FileNameRenderer fileNameRenderer,
-            final DescriptionProvider descriptionProvider, final Blames blames) {
+            final DescriptionProvider descriptionProvider, final GsResults gsResults) {
         super(ageBuilder, fileNameRenderer, descriptionProvider);
 
-        this.blames = blames;
+        this.gsResults = gsResults;
     }
 
     @Override
@@ -52,6 +52,7 @@ class ScmPropertiesDetailsModel extends DetailsTableModel {
         visibleColumns.add(Messages.Table_Column_Details());
         visibleColumns.add(Messages.Table_Column_File());
         visibleColumns.add(Messages.Table_Column_Age());
+        // FIXME: add correct headers
         visibleColumns.add("#Committers");
         visibleColumns.add("#Changes");
         visibleColumns.add("#LastModified");
@@ -64,10 +65,18 @@ class ScmPropertiesDetailsModel extends DetailsTableModel {
         columns.add(formatDetails(issue, description));
         columns.add(formatFileName(issue));
         columns.add(formatAge(issue));
-        // TODO: Add actual values for the specified issue
-        columns.add(UNDEFINED);
-        columns.add(UNDEFINED);
-        columns.add(UNDEFINED);
+        if (gsResults.contains(issue.getFileName())) {
+            GsResult result = gsResults.get(issue.getFileName());
+            // FIXME: add correct formatting
+            columns.add(String.valueOf(result.getSize()));
+            columns.add(UNDEFINED);
+            columns.add(String.valueOf(result.getAge()));
+        }
+        else {
+            columns.add(UNDEFINED);
+            columns.add(UNDEFINED);
+            columns.add(UNDEFINED);
+        }
         return columns;
     }
 }

--- a/src/main/java/io/jenkins/plugins/analysis/core/model/ScmPropertiesDetailsModel.java
+++ b/src/main/java/io/jenkins/plugins/analysis/core/model/ScmPropertiesDetailsModel.java
@@ -7,7 +7,6 @@ import edu.hm.hafner.analysis.Issue;
 import edu.hm.hafner.analysis.Report;
 
 import io.jenkins.plugins.analysis.core.model.StaticAnalysisLabelProvider.AgeBuilder;
-import io.jenkins.plugins.analysis.core.scm.BlameRequest;
 import io.jenkins.plugins.analysis.core.scm.Blames;
 
 /**
@@ -22,12 +21,13 @@ import io.jenkins.plugins.analysis.core.scm.Blames;
  *
  * @author Ullrich Hafner
  */
-class ReferenceDetailsModel extends DetailsTableModel {
+class ScmPropertiesDetailsModel extends DetailsTableModel {
     static final String UNDEFINED = "-";
 
+    // FIXME: replace with Dipp Model
     private final Blames blames;
 
-    ReferenceDetailsModel(final AgeBuilder ageBuilder, final FileNameRenderer fileNameRenderer,
+    ScmPropertiesDetailsModel(final AgeBuilder ageBuilder, final FileNameRenderer fileNameRenderer,
             final DescriptionProvider descriptionProvider, final Blames blames) {
         super(ageBuilder, fileNameRenderer, descriptionProvider);
 
@@ -52,9 +52,9 @@ class ReferenceDetailsModel extends DetailsTableModel {
         visibleColumns.add(Messages.Table_Column_Details());
         visibleColumns.add(Messages.Table_Column_File());
         visibleColumns.add(Messages.Table_Column_Age());
-        visibleColumns.add("Author");
-        visibleColumns.add("Email");
-        visibleColumns.add("Commit");
+        visibleColumns.add("#Committers");
+        visibleColumns.add("#Changes");
+        visibleColumns.add("#LastModified");
         return visibleColumns;
     }
 
@@ -64,18 +64,10 @@ class ReferenceDetailsModel extends DetailsTableModel {
         columns.add(formatDetails(issue, description));
         columns.add(formatFileName(issue));
         columns.add(formatAge(issue));
-        if (blames.contains(issue.getFileName())) {
-            BlameRequest blameRequest = blames.get(issue.getFileName());
-            int line = issue.getLineStart();
-            columns.add(blameRequest.getName(line));
-            columns.add(blameRequest.getEmail(line));
-            columns.add(blameRequest.getCommit(line));
-        }
-        else {
-            columns.add(UNDEFINED);
-            columns.add(UNDEFINED);
-            columns.add(UNDEFINED);
-        }
+        // TODO: Add actual values for the specified issue
+        columns.add(UNDEFINED);
+        columns.add(UNDEFINED);
+        columns.add(UNDEFINED);
         return columns;
     }
 }

--- a/src/main/java/io/jenkins/plugins/analysis/core/model/StaticAnalysisLabelProvider.java
+++ b/src/main/java/io/jenkins/plugins/analysis/core/model/StaticAnalysisLabelProvider.java
@@ -110,9 +110,27 @@ public class StaticAnalysisLabelProvider implements DescriptionProvider {
      *
      * @return the table model
      */
-    public DetailsTableModel getScmModel(final Run<?, ?> build,
+    public DetailsTableModel getScmBlamesModel(final Run<?, ?> build,
             final String url, final Blames blames) {
         return new ReferenceDetailsModel(getAgeBuilder(build, url),
+                getFileNameRenderer(build), this, blames);
+    }
+
+    /**
+     * Returns the model for the details table.
+     *
+     * @param build
+     *         the build of the results
+     * @param url
+     *         the URL of the results
+     * @param blames
+     *         the SCM blames
+     *
+     * @return the table model
+     */
+    public DetailsTableModel getScmPropertiesModel(final Run<?, ?> build,
+            final String url, final Blames blames) {
+        return new ScmPropertiesDetailsModel(getAgeBuilder(build, url),
                 getFileNameRenderer(build), this, blames);
     }
 

--- a/src/main/java/io/jenkins/plugins/analysis/core/model/StaticAnalysisLabelProvider.java
+++ b/src/main/java/io/jenkins/plugins/analysis/core/model/StaticAnalysisLabelProvider.java
@@ -18,6 +18,7 @@ import hudson.model.BallColor;
 import hudson.model.Run;
 
 import io.jenkins.plugins.analysis.core.scm.Blames;
+import io.jenkins.plugins.analysis.core.scm.GsResults;
 import io.jenkins.plugins.analysis.core.util.JenkinsFacade;
 import io.jenkins.plugins.analysis.core.util.QualityGateStatus;
 
@@ -123,15 +124,13 @@ public class StaticAnalysisLabelProvider implements DescriptionProvider {
      *         the build of the results
      * @param url
      *         the URL of the results
-     * @param blames
-     *         the SCM blames
      *
      * @return the table model
      */
     public DetailsTableModel getScmPropertiesModel(final Run<?, ?> build,
-            final String url, final Blames blames) {
+            final String url, final GsResults gsResults) {
         return new ScmPropertiesDetailsModel(getAgeBuilder(build, url),
-                getFileNameRenderer(build), this, blames);
+                getFileNameRenderer(build), this, gsResults);
     }
 
     /**

--- a/src/main/java/io/jenkins/plugins/analysis/core/scm/GsResults.java
+++ b/src/main/java/io/jenkins/plugins/analysis/core/scm/GsResults.java
@@ -15,4 +15,21 @@ public class GsResults implements Serializable {
     public void setResults(final Map<String, GsResult> results) {
         this.results = results;
     }
+
+    public void addAll(final GsResults other) {
+        results.putAll(
+                other.getResults()); // overwrites results for the same file, but GsResult will contain the same information anyway
+    }
+
+    public boolean contains(final String fileName) {
+        return results.containsKey(fileName);
+    }
+
+    public GsResult get(final String fileName) {
+        return results.get(fileName);
+    }
+
+    public void add(final String fileName, final GsResult gsResult) {
+        results.put(fileName, gsResult);
+    }
 }

--- a/src/main/java/io/jenkins/plugins/analysis/core/scm/GsWorker.java
+++ b/src/main/java/io/jenkins/plugins/analysis/core/scm/GsWorker.java
@@ -96,10 +96,14 @@ public class GsWorker implements Serializable {
             catch (Exception e) {
                 report.logInfo("Error reading git for filechanges", e);
             }
+            GsResults gsResults = new GsResults();
             for (Map.Entry<String, Integer> entry : lastChangedPerFile.entrySet()) {
-                report.logInfo("found {} - {} ", entry.getKey(), entry.getValue());
+                report.logInfo("found {%s} - {%d} ", entry.getKey(), entry.getValue());
+                GsResult gsResult = new GsResult();
+                gsResult.setAge(entry.getValue());
+                gsResults.add(workspace + "/" + entry.getKey(), gsResult);
             }
-            return new GsResults();
+            return gsResults;
         }
 
     }

--- a/src/main/java/io/jenkins/plugins/analysis/core/steps/AnnotatedReport.java
+++ b/src/main/java/io/jenkins/plugins/analysis/core/steps/AnnotatedReport.java
@@ -25,7 +25,7 @@ public final class AnnotatedReport implements Serializable {
     private final String id;
     private final Report aggregatedReport = new Report();
     private final Blames aggregatedBlames = new Blames();
-    private GsResults gsResults;
+    private final GsResults aggregatedGsResults = new GsResults();
     private final Map<String, Integer> sizeOfOrigin = new HashMap<>();
 
     /**
@@ -47,7 +47,7 @@ public final class AnnotatedReport implements Serializable {
      *         report with issues
      */
     public AnnotatedReport(@Nullable final String id, final Report report) {
-        this(id, report, new Blames());
+        this(id, report, new Blames(), new GsResults());
     }
 
     /**
@@ -63,25 +63,7 @@ public final class AnnotatedReport implements Serializable {
     public AnnotatedReport(@Nullable final String id, final Report report, final Blames blames, final GsResults gsResults) {
         this(id);
 
-        addReport(id, report, blames);
-        this.gsResults = gsResults;
-
-    }
-
-    /**
-     * Creates a new instance of {@link AnnotatedReport}.
-     *
-     * @param id
-     *         ID of the report
-     * @param report
-     *         report with issues
-     * @param blames
-     *         author and commit information
-     */
-    public AnnotatedReport(@Nullable final String id, final Report report, final Blames blames) {
-        this(id);
-
-        addReport(id, report, blames);
+        addReport(id, report, blames, gsResults);
     }
 
     /**
@@ -125,6 +107,10 @@ public final class AnnotatedReport implements Serializable {
      */
     public Report getReport() {
         return aggregatedReport;
+    }
+
+    public GsResults getGsResults() {
+        return aggregatedGsResults;
     }
 
     /**
@@ -185,7 +171,7 @@ public final class AnnotatedReport implements Serializable {
      *         the ID to use when adding the report
      */
     public void add(final AnnotatedReport other, final String actualId) {
-        addReport(actualId, other.getReport(), other.getBlames());
+        addReport(actualId, other.getReport(), other.getBlames(), other.getGsResults());
     }
 
     /**
@@ -200,9 +186,10 @@ public final class AnnotatedReport implements Serializable {
         add(other, getId());
     }
 
-    private void addReport(final String actualId, final Report report, final Blames blames) {
+    private void addReport(final String actualId, final Report report, final Blames blames, final GsResults gsResults) {
         aggregatedReport.addAll(report);
         sizeOfOrigin.merge(actualId, report.size(), Integer::sum);
         aggregatedBlames.addAll(blames);
+        aggregatedGsResults.addAll(gsResults);
     }
 }

--- a/src/main/java/io/jenkins/plugins/analysis/core/steps/IssuesAggregator.java
+++ b/src/main/java/io/jenkins/plugins/analysis/core/steps/IssuesAggregator.java
@@ -77,7 +77,7 @@ public class IssuesAggregator extends MatrixAggregator {
     }
 
     private AnnotatedReport createReport(final String id, final AnalysisResult result) {
-        return new AnnotatedReport(id, result.getIssues(), result.getBlames());
+        return new AnnotatedReport(id, result.getIssues(), result.getBlames(), result.getGsResults());
     }
 
     private void updateMap(final List<ResultAction> actions) {

--- a/src/main/resources/issues/details.jelly
+++ b/src/main/resources/issues/details.jelly
@@ -32,9 +32,12 @@
               </li>
               <j:if test="${!it.isBlameDisabled()}">
                 <li class="nav-item">
-                  <a class="nav-link" role="tab" data-toggle="tab" href="#scmContent">Source Control</a>
+                  <a class="nav-link" role="tab" data-toggle="tab" href="#scmBlamesContent">SCM Blames</a>
                 </li>
               </j:if>
+              <li class="nav-item">
+                <a class="nav-link" role="tab" data-toggle="tab" href="#scmPropertiesContent">SCM Properties</a>
+              </li>
             </j:if>
 
           </ul>
@@ -54,8 +57,9 @@
             <j:if test="${i.isNotEmpty()}">
               <issues:table tableId="issues" issues="${i}" model="${it.issuesModel}"/>
               <j:if test="${!it.isBlameDisabled()}">
-                <issues:table tableId="scm" issues="${i}" model="${it.scmModel}"/>
+                <issues:table tableId="scmBlames" issues="${i}" model="${it.scmBlamesModel}"/>
               </j:if>
+              <issues:table tableId="scmProperties" issues="${i}" model="${it.scmPropertiesModel}"/>
             </j:if>
 
           </div>

--- a/src/main/webapp/js/issues-detail.js
+++ b/src/main/webapp/js/issues-detail.js
@@ -21,7 +21,8 @@
      * Create data table instances for the detail tables.
      */
     showTable('#issues');
-    showTable('#scm');
+    showTable('#scmBlames');
+    showTable('#scmProperties');
 
     /**
      * Activate the tab that has been visited the last time. If there is no such tab, highlight the first one.

--- a/src/test/resources/design.puml
+++ b/src/test/resources/design.puml
@@ -17,6 +17,7 @@ skinparam component {
 [Columns] <<..core.columns>>
 [Rest API] <<..core.restapi>>
 [SCM] <<..core.scm>>
+[SCM Properties] <<..core.scm.analyzer>>
 [Tokens] <<..core.tokens>>
 [Utilities] <<..core.util>> <<..api>>
 
@@ -46,5 +47,7 @@ skinparam component {
 [Rest API] --> [Utilities]
 [Filter] --> [Utilities]
 [SCM] --> [Utilities]
+
+[SCM] --> [SCM Properties]
 
 @enduml


### PR DESCRIPTION
Ich habe jetzt mal das Tab mit der Tabelle mit Ihren GsResults verknüpft. Angezeigt werden nun schon mal die Timestamps. 

Die Daten werden auch im Build gespeichert. Funktioniert soweit. Momentan werden allerdings die Infos von allen Dateien gespeichert, nicht nur von denen mit Warnungen, da gibt es noch Optimierungpotential, ist aber erst mal nicht wichtig. Erstmal sollte die Funktionalität passen. 

Auch werden pro Tool (und wohl auch pro Property die Sie ermitteln) ein kompletter Scan des Git Repositories gemacht, dass lässt sich sicher auch optimieren (nach Ihrer Arbeit). Ich denke es macht da wohl Sinn ein eigenes Plugin zu schreiben, dass die Git Analyse (auch die Blames) durchführt und dann per API zur Verfügung stellt. Das werde ich dann nach Ihrer Arbeit in Angriff nehmen ;-)